### PR TITLE
allow interaction with slower API server, limit max to 3 minutes and …

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,7 +5,7 @@
       <setting label="30301" type="text"   id="username" default=""/>
       <setting label="30302" type="text"   id="password" option="hidden" default=""/>
       <setting label="30303" type="slider" id="refresh" default="8" range="0.5,0.5,10" option="float" />
-      <setting label="30304" type="slider" id="timeout" default="10.0" range="0.5,0.5,20" option="float" />
+      <setting label="30304" type="slider" id="timeout" default="10.0" range="1,1,180" option="float" />
       <setting label="30305" type="text"   id="base" default="https://api.iptv.bulsat.com"/>
       <setting label=""      type="bool"   id="firstrun" visible="false" default="true"/>
     </category>


### PR DESCRIPTION
A couple of days ago it happened that the bulsatcom api server got very slow to respond, a simple curl would generate the result in about 170 seconds.

The current configuration state of the plugin does not allow the user to increase the timeout to anything greater than 20 seconds.

The pull request increases the configurable timeout to 3 minutes with minimum changed to 1 second and stepping set to 1 second on the slider.

Here is the python stack trace(when at 10 seconds) for the session timeout:
`ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <class 'requests.exceptions.ReadTimeout'>
                                            Error Contents: HTTPSConnectionPool(host='api.iptv.bulsat.com', port=443): Read timed out. (read timeout=10.0)
                                            Traceback (most recent call last):
                                              File "/home/kodi/.kodi/addons/plugin.program.bscfusion/service.py", line 145, in <module>
                                                monitor = MyMonitor()
                                              File "/home/kodi/.kodi/addons/plugin.program.bscfusion/service.py", line 116, in __init__
                                                m_start()
                                              File "/home/kodi/.kodi/addons/plugin.program.bscfusion/service.py", line 108, in m_start
                                                server.my_serv.start()
                                              File "/home/kodi/.kodi/addons/plugin.program.bscfusion/resources/lib/server.py", line 185, in start
                                                self._datas['dat'], self._datas['ua']= b.gen_all()
                                              File "/home/kodi/.kodi/addons/plugin.program.bscfusion/resources/lib/bsc.py", line 230, in gen_all
                                                self.__goforit()
                                              File "/home/kodi/.kodi/addons/plugin.program.bscfusion/resources/lib/bsc.py", line 126, in __goforit
                                                headers=self.__UA)
                                              File "/home/kodi/.kodi/addons/script.module.requests/lib/requests/sessions.py", line 555, in post
                                                return self.request('POST', url, data=data, json=json, **kwargs)
                                              File "/home/kodi/.kodi/addons/script.module.requests/lib/requests/sessions.py", line 508, in request
                                                resp = self.send(prep, **send_kwargs)
                                              File "/home/kodi/.kodi/addons/script.module.requests/lib/requests/sessions.py", line 618, in send
                                                r = adapter.send(request, **kwargs)
                                              File "/home/kodi/.kodi/addons/script.module.requests/lib/requests/adapters.py", line 521, in send
                                                raise ReadTimeout(e, request=request)
                                            ReadTimeout: HTTPSConnectionPool(host='api.iptv.bulsat.com', port=443): Read timed out. (read timeout=10.0)
                                            -->End of Python script error report<--
`